### PR TITLE
FIX #8 - Option to mark slides to be included in TOC as subsections

### DIFF
--- a/typslides.typ
+++ b/typslides.typ
@@ -206,7 +206,7 @@
 
     if sections.len() == 0 {
       let subsections = query(<subsection>)
-      pad(enum(..subsections.map(subsection => link(subsection.location(), subsection))))
+      pad(enum(..subsections.map(subsection => link(subsection.location(), subsection.value))))
     } else {
       pad(enum(..sections.map(section => {
         let section_loc = section.location()

--- a/typslides.typ
+++ b/typslides.typ
@@ -202,8 +202,27 @@
 
     show linebreak: none
 
-    let sections = sections.final()
-    pad(enum(..sections.map(section => link(section.loc, section.body))))
+    let sections = query(<section>)
+
+    if sections.len() == 0 {
+      let subsections = query(<subsection>)
+      pad(enum(..subsections.map(subsection => link(subsection.location(), subsection))))
+    } else {
+      pad(enum(..sections.map(section => {
+        let section_loc = section.location()
+        let subsections = query(selector(<subsection>).after(section_loc).before(
+          selector(<section>).after(section_loc, inclusive: false)
+        ))
+        if subsections.len() != 0 {
+          link(section_loc, section.value) + list(
+            ..subsections.map(subsection => link(subsection.location(),
+            subsection.value))
+          )
+        } else {
+          link(section.location(), section.value)
+        }
+      })))
+    }
 
     pagebreak()
   }
@@ -222,7 +241,7 @@
 
     set align(left + horizon)
 
-    [= #smallcaps(body)]
+    [#heading(depth: 1, smallcaps(body)) #metadata(body) <section>]
 
     _divider(color: theme-color.get())
 
@@ -258,6 +277,7 @@
 #let slide(
   title: none,
   back-color: white,
+  outlined: false,
   body,
 ) = (
   context {
@@ -287,7 +307,7 @@
       } else {
         (x: 1.6cm, top: 1.75cm, bottom: 1.2cm)
       },
-      background: place(_slide-header(title, theme-color.get())),
+      background: place(_slide-header(title, outlined, theme-color.get())),
     )
 
     set list(marker: text(theme-color.get(), [•]))

--- a/utils.typ
+++ b/utils.typ
@@ -43,7 +43,7 @@
 
 //************************************************************************\\
 
-#let _slide-header(title, color) = {
+#let _slide-header(title, outlined, color) = {
   rect(
     fill: color,
     width: 100%,
@@ -53,7 +53,11 @@
       .95cm
     },
     inset: .6cm,
-    text(white, weight: "semibold", size: 24pt)[#h(.1cm) #title],
+    if outlined {
+      text(white, weight: "semibold", size: 24pt)[#h(.1cm) #title #metadata(title) <subsection>]
+    } else {
+      text(white, weight: "semibold", size: 24pt)[#h(.1cm) #title]
+    }
   )
 }
 


### PR DESCRIPTION
Fixes #8. Adds property `outlined` to `slide`. Default value is `false`.

Changes generation of TOC to use labels on metadata instead of states to support multiple kinds of sections. Old state variable `sections` is left unchanged, but no longer used by `table-of-contents`.

- If there are only sections, results are identical to previous behavior.
- If there are only subsections, subsections are outlined exactly as sections are otherwise.
- If sections and subsections are mixed, sections are outlined as before, with subsections appearing as bullet list items beneath their top-level section.