### PR TITLE
FEATURE: User settable font

### DIFF
--- a/typslides.typ
+++ b/typslides.typ
@@ -6,11 +6,12 @@
 #let typslides(
   ratio: "16-9",
   theme: "bluey",
+  font: "Fira Sans",
   body,
 ) = {
   theme-color.update(_theme-colors.at(theme))
 
-  set text(font: "Fira Sans")
+  set text(font: font)
   set page(paper: "presentation-" + ratio, fill: white)
 
   show ref: it => (


### PR DESCRIPTION
Adds `font` as a parameter to `typslides`, allowing any font to be chosen by the user.

Most conventional fonts have very similar sizing, so this should not normally create issues with font size. If it does, the default remains Fira Sans, which can always be fallen back on. **A possible extension of this PR might see a font size adjustment, allowing pt-based increasing or decreasing of font size to compensate for font size differences.**

For example: `typslides(fontsize-adjust: -4)` would make all font sizes set by the template be decreased by 4pt to allow finer control. I would welcome discussion and feedback on this though, as I think it's also important to retain ease of use.