### PR TITLE
FEATURE: User settable theme besides base options

### DIFF
--- a/typslides.typ
+++ b/typslides.typ
@@ -44,6 +44,7 @@
 
 // Theme colors
 
+#let themey(body) = context (text(fill: theme-color.get())[#body])
 #let bluey(body) = (text(fill: rgb("3059AB"))[#body])
 #let greeny(body) = (text(fill: rgb("BF3D3D"))[#body])
 #let reddy(body) = (text(fill: rgb("28842F"))[#body])

--- a/typslides.typ
+++ b/typslides.typ
@@ -8,7 +8,11 @@
   theme: "bluey",
   body,
 ) = {
-  theme-color.update(_theme-colors.at(theme))
+  if type(theme) == str {
+    theme-color.update(_theme-colors.at(theme))
+  } else {
+    theme-color.update(theme)
+  }
 
   set text(font: "Fira Sans")
   set page(paper: "presentation-" + ratio, fill: white)


### PR DESCRIPTION
Allows typst color values or `rbg()`-values to be set for the `theme` parameter of `typslides`. This allows finer control for the color of the theme if the base options are insufficient.

Also add `#themey[content]` as a function to color anything with the user set theme color.