### PR TITLE
FIX #14 - Merge PRs for link stylings and subheadings in TOC

### DIFF
--- a/typslides.typ
+++ b/typslides.typ
@@ -217,8 +217,27 @@
 
     show linebreak: none
 
-    let sections = sections.final()
-    pad(enum(..sections.map(section => [#link(section.loc, section.body) <toc>])))
+    let sections = query(<section>)
+
+    if sections.len() == 0 {
+      let subsections = query(<subsection>)
+      pad(enum(..subsections.map(subsection => [#link(subsection.location(), subsection.value) <toc>])))
+    } else {
+      pad(enum(..sections.map(section => {
+        let section_loc = section.location()
+        let subsections = query(selector(<subsection>).after(section_loc).before(
+          selector(<section>).after(section_loc, inclusive: false)
+        ))
+        if subsections.len() != 0 {
+          [#link(section_loc, section.value) <toc> #list(
+            ..subsections.map(subsection => [#link(subsection.location(),
+            subsection.value) <toc>])
+          )]
+        } else {
+          [#link(section.location(), section.value) <toc>]
+        }
+      })))
+    }
 
     pagebreak()
   }


### PR DESCRIPTION
Fixes #14.

Developing against a common main branch often introduces these kinds of conflicts, the subheading logic just needed the `<toc>` label applied to exclude those links from the styling.