### PR TITLE
Fixed bug causing duplicated outline entries

### DIFF
--- a/typslides.typ
+++ b/typslides.typ
@@ -341,17 +341,19 @@
   set text(size: text-size)
   show linebreak: none
 
-  let sections = query(<section>)
+  // Deduplication is done to prevent natural page breaking causing multiplied
+  // outline entries.
+  let sections = query(<section>).dedup()
 
   if sections.len() == 0 {
-    let subsections = query(<subsection>)
+    let subsections = query(<subsection>).dedup()
     pad(enum(..subsections.map(sub => [#link(sub.location(), sub.value) <toc>])))
   } else {
     pad(enum(..sections.map(section => {
       let section-loc = section.location()
       let subsections = query(
         selector(<subsection>).after(section-loc).before(selector(<section>).after(section-loc, inclusive: false)),
-      )
+      ).dedup()
 
       if subsections.len() != 0 {
         [#link(section-loc, section.value) <toc> #list(


### PR DESCRIPTION
I just noticed that when setting `outlined: true` for slides and then including content that leads to page breaks, the outline will be repeated in the TOC for every page that was generated.

This is a quick fix but it should be robust. The arrays of sections are simply deduplicated, since I cannot think of a valid use-case where a user wants to put the same outline in the TOC multiple times without some break between them.

The following edge-case does not get broken by the fix:
1. First candidate
    - CV
2. Second candidate
    - CV

This is because the subsections are queried only for the correct span between top level sections so the deduplication doesn't affect repeats under other top level sections.