### PR TITLE
Adds margin parameter for front-slide

### DIFF
--- a/typslides.typ
+++ b/typslides.typ
@@ -316,6 +316,7 @@
   authors: none,
   info: none,
   back-color: none,
+  margin: auto,
 ) = context {
   let bg-color = if back-color != none { back-color } else { default-back-color.get() }
   
@@ -327,6 +328,7 @@
     authors,
     info,
     theme-color.get(),
+    margin,
   )
 }
 

--- a/utils.typ
+++ b/utils.typ
@@ -188,9 +188,10 @@
   authors,
   info,
   theme-color,
+  margin,
 ) = {
   set align(left + horizon)
-  set page(footer: none)
+  set page(footer: none, margin: margin)
 
   text(40pt, weight: "bold")[#smallcaps(title)]
   v(-.95cm)


### PR DESCRIPTION
Allows users to adjust the margin of the front slide.

e.g.
```typst
#front-slide(
  margin: (bottom: 1cm),
  title: "Some slides with a smaller bottom margin",
)
```

Default behaviour is unchanged as `auto` is set by default.